### PR TITLE
Added time lib + rewrote anti-file overwrite loop

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -51,6 +51,7 @@ Includes all git commit authors. Aliases are GitHub user names.
 * Hugo Wallenburg (Goddesen) - Misc.
 * (Nubbie) - Misc, UX
 * Daniel Trujillo Viedma (gDanix) - Custom currency.
+* Niels NTG Poldervaart (Niels-NTG) - Misc.
 
 ## Bug fixes
 * (halfbro)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Feature: Objects are scanned from the user directory as well as the RCT2 directory.
 - Feature: Objects directory is scanned recursively.
 - Improve: Performance and reliability of loading objects.
+- Improve: Screenshots are now saved with the name of the park and the current date and time.
 - Removed: BMP screenshots.
 - Removed: Intamin and Phoenix easter eggs.
 - Fix: [#1038] Guest List is out of order.

--- a/src/game.c
+++ b/src/game.c
@@ -55,7 +55,6 @@
 #include "world/scenery.h"
 #include "world/sprite.h"
 #include "world/water.h"
-#include <time.h>
 
 #define NUMBER_OF_AUTOSAVES_TO_KEEP 9
 
@@ -984,18 +983,17 @@ void game_autosave()
 	utf8 path[MAX_PATH];
 	utf8 backupPath[MAX_PATH];
 	utf8 timeString[21]="";
-	
-	time_t rawtime;
-	struct tm * timeinfo;
-	
-	time ( &rawtime );
-	timeinfo = localtime ( &rawtime );
+
+	// retrieve current time
+	rct2_date currentDate;
+	platform_get_date_local(&currentDate);
+	rct2_time currentTime;
+	platform_get_time_local(&currentTime);
+
+	sprintf(timeString, "%d-%02d-%02d_%02d-%02d-%02d", currentDate.year, currentDate.month, currentDate.day, currentTime.hour, currentTime.minute,currentTime.second);
 
 	limit_autosave_count(NUMBER_OF_AUTOSAVES_TO_KEEP);
-	
-	snprintf(timeString, 20, "%d-%02d-%02d_%02d-%02d-%02d", 1900+timeinfo->tm_year, 1+timeinfo->tm_mon, timeinfo->tm_mday, timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec);
-	
-	
+
 	platform_get_user_directory(path, "save");
 	safe_strcpy(backupPath, path, MAX_PATH);
 

--- a/src/interface/screenshot.c
+++ b/src/interface/screenshot.c
@@ -45,9 +45,8 @@ void screenshot_check()
 
 			if (screenshotIndex != -1) {
 				RCT2_GLOBAL(0x009A8C29, uint8) |= 1;
-				
-				// TODO use a more obvious sound like a camera shutter
-				audio_play_sound(SOUND_CLICK_1, 0, gScreenWidth / 2);
+
+				audio_play_sound(SOUND_WINDOW_OPEN, 100, gScreenWidth / 2);
 			} else {
 				window_error_open(STR_SCREENSHOT_FAILED, STR_NONE);
 			}
@@ -84,15 +83,13 @@ static int screenshot_get_next_path(char *path)
 	format_string(park_name, gParkName, &gParkNameArgs);
 
 	// retrieve current time
-	time_t now;
-	time(&now);
-	struct tm* tm_now = localtime(&now);
+	rct2_date currentDate;
+	platform_get_date_local(&currentDate);
+	rct2_time currentTime;
+	platform_get_time_local(&currentTime);
 
-	utf8 time_now_str[128] = { 0 };
-	size_t size = strftime(time_now_str, 128, "%F %H-%M-%S", tm_now);
-	assert(size != 0);
-
-	sprintf(path, "%s%s %s.png", screenshotPath, park_name, time_now_str);
+	// Glue together path and filename
+	sprintf(path, "%s%s %d-%02d-%02d %02d-%02d-%02d.png", screenshotPath, park_name, currentDate.year, currentDate.month, currentDate.day, currentTime.hour, currentTime.minute, currentTime.second);
 
 	if (!platform_file_exists(path)) {
 		return 0; // path ok
@@ -100,19 +97,21 @@ static int screenshot_get_next_path(char *path)
 
 	// multiple screenshots with same timestamp
 	// might be possible when switching timezones
-	// but should not happen
+	// in the unlikely case that this does happen,
+	// append (%d) to the filename and increment
+	// this int until it doesn't overwrite any
+	// other file in the directory.
 	int i;
-	for (i = 2; i < 1000; i++) {
-		set_format_arg(0, uint16, i);
+	for (i = 1; i < 1000; i++) {
 		// Glue together path and filename
-		sprintf(path, "%s%s %s (%d).png", screenshotPath, park_name, time_now_str, i);
+		sprintf(path, "%s%s %d-%02d-%02d %02d-%02d-%02d (%d).png", screenshotPath, park_name, currentDate.year, currentDate.month, currentDate.day, currentTime.hour, currentTime.minute, currentTime.second, i);
 
 		if (!platform_file_exists(path)) {
 			return i;
 		}
 	}
 
-	log_error("You have too many saved screenshots.\n");
+	log_error("You have too many saved screenshots saved at exactly the same date and time.\n");
 	return -1;
 }
 

--- a/src/platform/platform.h
+++ b/src/platform/platform.h
@@ -133,8 +133,10 @@ void platform_process_messages();
 int platform_scancode_to_rct_keycode(int sdl_key);
 void platform_start_text_input(utf8 *buffer, int max_length);
 void platform_stop_text_input();
-void platform_get_date(rct2_date *out_date);
-void platform_get_time(rct2_time *out_time);
+void platform_get_date_utc(rct2_date *out_date);
+void platform_get_time_utc(rct2_time *out_time);
+void platform_get_date_local(rct2_date *out_date);
+void platform_get_time_local(rct2_time *out_time);
 
 // Platform specific definitions
 void platform_get_exe_path(utf8 *outPath);

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -64,7 +64,7 @@ int main(int argc, const char **argv)
 	return gExitCode;
 }
 
-void platform_get_date(rct2_date *out_date)
+void platform_get_date_utc(rct2_date *out_date)
 {
 	assert(out_date != NULL);
 	time_t rawtime;
@@ -72,18 +72,43 @@ void platform_get_date(rct2_date *out_date)
 	time(&rawtime);
 	timeinfo = gmtime(&rawtime);
 	out_date->day = timeinfo->tm_mday;
-	out_date->month = timeinfo->tm_mon;
-	out_date->year = timeinfo->tm_year;
+	out_date->month = timeinfo->tm_mon + 1;
+	out_date->year = timeinfo->tm_year + 1900;
 	out_date->day_of_week = timeinfo->tm_wday;
 }
 
-void platform_get_time(rct2_time *out_time)
+void platform_get_time_utc(rct2_time *out_time)
 {
 	assert(out_time != NULL);
 	time_t rawtime;
 	struct tm * timeinfo;
 	time(&rawtime);
 	timeinfo = gmtime(&rawtime);
+	out_time->second = timeinfo->tm_sec;
+	out_time->minute = timeinfo->tm_min;
+	out_time->hour = timeinfo->tm_hour;
+}
+
+void platform_get_date_local(rct2_date *out_date)
+{
+	assert(out_date != NULL);
+	time_t rawtime;
+	struct tm * timeinfo;
+	time(&rawtime);
+	timeinfo = localtime(&rawtime);
+	out_date->day = timeinfo->tm_mday;
+	out_date->month = timeinfo->tm_mon + 1;
+	out_date->year = timeinfo->tm_year + 1900;
+	out_date->day_of_week = timeinfo->tm_wday;
+}
+
+void platform_get_time_local(rct2_time *out_time)
+{
+	assert(out_time != NULL);
+	time_t rawtime;
+	struct tm * timeinfo;
+	time(&rawtime);
+	timeinfo = localtime(&rawtime);
 	out_time->second = timeinfo->tm_sec;
 	out_time->minute = timeinfo->tm_min;
 	out_time->hour = timeinfo->tm_hour;
@@ -201,7 +226,7 @@ bool platform_directory_delete(const utf8 *path)
 		switch (p->fts_info) {
 			case FTS_DP: // Directory postorder, which means
 						 // the directory is empty
-						 
+
 			case FTS_F:  // File
 				if(remove(p->fts_path)) {
 					log_error("Could not remove %s", p->fts_path);
@@ -232,7 +257,7 @@ bool platform_lock_single_instance()
 	safe_strcat_path(pidFilePath, SINGLE_INSTANCE_MUTEX_NAME, sizeof(pidFilePath));
 
 	// We will never close this file manually. The operating system will
-	// take care of that, because flock keeps the lock as long as the 
+	// take care of that, because flock keeps the lock as long as the
 	// file is open and closes it automatically on file close.
 	// This is intentional.
 	int pidFile = open(pidFilePath, O_CREAT | O_RDWR, 0666);
@@ -844,9 +869,9 @@ uint8 platform_get_locale_currency(){
 	if (langstring == NULL) {
 		return platform_get_currency_value(NULL);
 	}
-	
+
 	struct lconv *lc = localeconv();
-	
+
 	return platform_get_currency_value(lc->int_curr_symbol);
 }
 

--- a/src/platform/windows.c
+++ b/src/platform/windows.c
@@ -129,7 +129,7 @@ utf8 **windows_get_command_line_args(int *outNumArgs)
 	return argvUtf8;
 }
 
-void platform_get_date(rct2_date *out_date)
+void platform_get_date_local(rct2_date *out_date)
 {
 	assert(out_date != NULL);
 	SYSTEMTIME systime;
@@ -141,7 +141,7 @@ void platform_get_date(rct2_date *out_date)
 	out_date->day_of_week = systime.wDayOfWeek;
 }
 
-void platform_get_time(rct2_time *out_time)
+void platform_get_time_local(rct2_time *out_time)
 {
 	assert(out_time != NULL);
 	SYSTEMTIME systime;
@@ -909,7 +909,7 @@ uint8 platform_get_locale_currency()
 	) {
 		return platform_get_currency_value(NULL);
 	}
-	
+
 	return platform_get_currency_value(currCode);
 }
 


### PR DESCRIPTION
time.h needs to be imported in order to make this work in the first place.

Also the anti-file overwrite loop has been rewritten to get rid of the magic number 1000. All tough it's quite unlikely one manages to take multiple screenshot in 1 second or on the exact same date and time in a different time zone. The code is nicer this way.

Closes #4159